### PR TITLE
Patch 7.0.5861 seems to have removed the Squad_EntityAt which breaks relic tracking and causes a scar error

### DIFF
--- a/assets/scar/ObserverUI/Tracking_RelicLocations.scar
+++ b/assets/scar/ObserverUI/Tracking_RelicLocations.scar
@@ -28,14 +28,11 @@ function RelicLocations:_Initialize(player)
     ObserverUiRuleSystem:AddDataGatheringPreparationRule(player.PlayerID, rule)
     
     local entity_GetStateModelFloat = Entity_GetStateModelFloat
-    local squad_EntityAt = Squad_EntityAt
-    local squad_Count = Squad_Count
+    local squad_GetFirstEntity = Squad_GetFirstEntity
     local rule = function (squad)
-        for i = 1, squad_Count(squad) do
-            local entity = squad_EntityAt(squad, i - 1)
-            local relics = entity_GetStateModelFloat(entity, "Relic_Count")
-            relicLocations.Carried = relicLocations.Carried + relics
-        end
+        local entity = squad_GetFirstEntity(squad)
+        local relics = entity_GetStateModelFloat(entity, "Relic_Count")
+        relicLocations.Carried = relicLocations.Carried + relics
     end
     ObserverUiRuleSystem:AddSquadDataGatheringRule(player.PlayerID, "NonWorker", rule)
     


### PR DESCRIPTION
The `Squad_EntityAt` function seems to have been replaced with `Squad_GetFirstEntity`. As far as I understand all squads in AoE4 only have on entity per squad anyway so it should be ok although it does feel sketchy. Without the changes in this pull request, or something similar, the improved observer ui crashes while initialising the relic tracking module.